### PR TITLE
Add support for differing directories

### DIFF
--- a/refrapt/refrapt.conf.example
+++ b/refrapt/refrapt.conf.example
@@ -11,9 +11,17 @@
 
 # This is the default Architecture to be used if one is not specified in for a source.
 set architecture       = i386
-# The root path for Refrapt. Note that other paths are appended to this rootPath.
-# If not specified, Refrapt will default to using your home directory.
-# set rootPath           = /refrapt
+
+# For each of the path variables, if not specified, will be found in ~/refrapt
+# The root path for log files and the configuration file.
+# set rootPath   = ""
+# The directory where the mirror will be stored. This will be the larget directory, so use a large drive!
+# set mirrorPath = ""
+# Directory used for intermediate Index files. Recommend using an SSD for best performance during the building of file lists.
+# set skelPath   = ""
+# Directory used for storing log files and lock files. Recommend using an SSD for best performance.
+# set varPath    = ""
+
 # Specify whether the Contents-[arch].* files should be downloaded.
 set contents           = True
 # The number of threads to use for download and decompression. 

--- a/refrapt/settings.py
+++ b/refrapt/settings.py
@@ -1,6 +1,5 @@
 import multiprocessing
 import logging
-import os
 from pathlib import Path
 import platform
 
@@ -10,6 +9,9 @@ class Settings:
     _settings = {
         "architecture"      : platform.machine(),
         "rootPath"          : f"{str(Path.home())}/refrapt",
+        "mirrorPath"        : f"{str(Path.home())}/refrapt/mirror",
+        "skelPath"          : f"{str(Path.home())}/refrapt/skel",
+        "varPath"           : f"{str(Path.home())}/refrapt/var",
         "contents"          : True,
         "threads"           : multiprocessing.cpu_count(),
         "authNoChallenge"   : False,
@@ -75,17 +77,17 @@ class Settings:
     @staticmethod
     def MirrorPath() -> str:
         """Get the path to the /mirror directory."""
-        return str(Settings._settings["rootPath"]) + os.sep + "mirror"
+        return str(Settings._settings["mirrorPath"])
 
     @staticmethod
     def SkelPath() -> str:
         """Get the path to the /skel directory."""
-        return str(Settings._settings["rootPath"]) + os.sep + "skel"
+        return str(Settings._settings["skelPath"])
 
     @staticmethod
     def VarPath() -> str:
         """Get the path to the /var directory."""
-        return str(Settings._settings["rootPath"]) + os.sep + "var"
+        return str(Settings._settings["varPath"])
 
     @staticmethod
     def Contents() -> bool:


### PR DESCRIPTION
You can now set the following directories explicitly if desired via the Configuration file:

- rootPath
- mirrorPath
- skelPath
- varPath

By default, all paths use `f{str(Path.home())}/refrapt` as the root.
