### PR TITLE
Only Process Unique URIs for Cleaning

### DIFF
--- a/refrapt/refrapt.py
+++ b/refrapt/refrapt.py
@@ -256,8 +256,10 @@ def Clean():
        are not required.
     """
     logger.info("Compiling list of files to clean...")
-    for source in tqdm.tqdm([x for x in sources if x.Clean], unit=" sources"):
-        directory = SanitiseUri(source.Uri)
+    cleanSources = [x for x in sources if x.Clean]
+    uris = {source.Uri for source in cleanSources}
+    for uri in tqdm.tqdm(uris, unit=" mirrors"):
+        directory = SanitiseUri(uri)
         if os.path.isdir(directory) and not os.path.islink(directory):
             ProcessDirectory(directory)
 


### PR DESCRIPTION
Fix a bug where a sources with the same URI were each being processed during the Clean process, causing excess recursion down the same tree, and leading to files / directories being added to the list for cleaning multiple times, leading to an error when attempting to be removed a subsequent time.

Changed to get a unique list of URIs and process those only.