### PR TITLE
Translation file locale

### DIFF
--- a/refrapt/refrapt.conf.example
+++ b/refrapt/refrapt.conf.example
@@ -73,6 +73,10 @@ set logLevel           = INFO
 set test               = False
 # Specify whether Refrapt should download the /by-hash/* directories and contents for each available checksum.
 set byHash             = False
+# Limits the download of Translation files for that of your locale. When not specified, Refrapt will default to locale.getdefaultlocale().
+# Note that "_XX" languages will be stripped of the locale to collect a wider number of files. Ie "en_GB" becomes "en", which will capture 
+# files with the same base language, but different locales.
+# set language           = "en_GB"
 
 #################
 ## SOURCE LIST ##

--- a/refrapt/refrapt.conf.example
+++ b/refrapt/refrapt.conf.example
@@ -53,8 +53,10 @@ set privateKey         = ""
 # Note that this will be multipled by the number of threads specified.
 # See Wget manpage for correct syntax
 set limitRate          = 500m # 500 MB
-# Currently unused - Potential to be used for limiting the Translation Indexes to those for the current locale.
-set language           = en 
+# Limits the download of Translation files for that of your locale. When not specified, Refrapt will default to locale.getdefaultlocale().
+# Note that "_XX" languages will be stripped of the locale to collect a wider number of files. Ie "en_GB" becomes "en", which will capture 
+# files with the same base language, but different locales.
+# set language           = "en_GB"
 # Tell Refrapt to update all files, regardless of whether they are deemed to have changed or not.
 # Note that if Wget determines the files are unchanged (via Timestamping), this will have no effect.
 # The use of this should be limited for when you know a package has changed, but the size has not 
@@ -73,10 +75,6 @@ set logLevel           = INFO
 set test               = False
 # Specify whether Refrapt should download the /by-hash/* directories and contents for each available checksum.
 set byHash             = False
-# Limits the download of Translation files for that of your locale. When not specified, Refrapt will default to locale.getdefaultlocale().
-# Note that "_XX" languages will be stripped of the locale to collect a wider number of files. Ie "en_GB" becomes "en", which will capture 
-# files with the same base language, but different locales.
-# set language           = "en_GB"
 
 #################
 ## SOURCE LIST ##

--- a/refrapt/settings.py
+++ b/refrapt/settings.py
@@ -2,6 +2,7 @@ import multiprocessing
 import logging
 from pathlib import Path
 import platform
+import locale
 
 logger = logging.getLogger(__name__)
 
@@ -26,7 +27,7 @@ class Settings:
         "caCertificate"     : None,
         "privateKey"        : None,
         "limitRate"         : "500m", # Wget syntax
-        "language"          : "en",   # TODO : Default to locale
+        "language"          : locale.getdefaultlocale()[0],
         "forceUpdate"       : False,  # Use this to flag every single file as requiring an update, regardless of if the size matches. Use this if you know a file has changed, but you still have the old version (sizes were equal)
         "logLevel"          : "INFO",
         "test"              : False,
@@ -54,6 +55,10 @@ class Settings:
                     logger.debug(f"Parsed setting: {key} = {Settings._settings.get(key)}")
                 else:
                     logger.warn(f"Unknown setting in configuration file '{line}'")
+
+        # Shorten specific locales like en_GB to en to catch more files
+        if "_" in Settings.Language():
+            Settings._settings["language"] = Settings.Language().split("_")[0]
 
     @staticmethod
     def Test() -> bool:


### PR DESCRIPTION
Limit download of Translation files to local language.

Langauges that inclue locales such as en_GB will be stripped of the locale, and any Translation files that include "en" will be included to ensure the best support.