### PR TITLE
Add Clean Mode + Bug Fix

### DIFF
--- a/refrapt/classes.py
+++ b/refrapt/classes.py
@@ -109,7 +109,7 @@ class Source:
 
         return releaseFiles
 
-    def ParseReleaseFiles(self) -> list:
+    def _ParseReleaseFiles(self, rootPath: str) -> list:
         """Get a list of all Index files from the InRelease file (dists/$DIST/InRelease).
 
            If the InRelease file does not exist, fall back to the Release file (dists/$DIST/Release).
@@ -119,8 +119,8 @@ class Source:
         if self._components:
             baseUrl += "dists/" + self._distribution + "/"
 
-        inReleaseFilePath = Settings.SkelPath() + "/" + SanitiseUri(baseUrl) + "/InRelease"
-        releaseFilePath   = Settings.SkelPath() + "/" + SanitiseUri(baseUrl) + "/Release"
+        inReleaseFilePath = rootPath + "/" + SanitiseUri(baseUrl) + "/InRelease"
+        releaseFilePath   = rootPath + "/" + SanitiseUri(baseUrl) + "/Release"
 
         # Default to InRelease
         releaseFileToRead = inReleaseFilePath
@@ -229,6 +229,12 @@ class Source:
         self._indexCollection.DetermineCurrentTimestamps()
 
         return list(set(indexFiles)) # Remove duplicates
+
+    def ParseReleaseFilesOnDisk(self) -> list:
+        return self._ParseReleaseFiles(Settings.MirrorPath())
+
+    def ParseReleaseFiles(self) -> list:
+        return self._ParseReleaseFiles(Settings.SkelPath())
 
     def Timestamp(self):
         """Get the timestamps for all registered files after they have been downloaded."""

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ README = (HERE / "README.md").read_text()
 
 setup(
     name='Refrapt',
-    version='0.3.5',
+    version='0.4.0',
     description='A tool to mirror Debian repositories for use as a local mirror.',
     python_requires='>=3.9',
     long_description=README,
@@ -27,8 +27,13 @@ setup(
     ],
     classifiers=[
         "Development Status :: 4 - Beta",
+        "Intended Audience :: Developers",
+        "Intended Audience :: End Users/Desktop",
+        "Intended Audience :: System Administrators",
+        "Natural Language :: English",
         "Operating System :: Microsoft :: Windows :: Windows 10",
         "Operating System :: POSIX :: Linux",
+        "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: Implementation",
         "Topic :: System :: Archiving :: Mirroring"
     ],


### PR DESCRIPTION
Add the ability to only run the Cleaning process on an existing mirror. Does not perform any downloads. Can be used in conjunction with --Test mode.

Fixes #18.