### PR TITLE
Add regex feature

### DIFF
--- a/refrapt/classes.py
+++ b/refrapt/classes.py
@@ -54,7 +54,7 @@ class Package:
 
 class Repository:
     """Represents a Repository as defined the Configuration file."""
-    def __init__(self, line, defaultArch):
+    def __init__(self, line, defaultArch, regex):
         """Initialises a Repository with a line from the Configuration file and the default Architecture."""
         self._repositoryType = RepositoryType.Bin
         self._architectures = [] # type: list[str]
@@ -62,6 +62,7 @@ class Repository:
         self._distribution = None
         self._components = [] # type: list[str]
         self._clean = True
+        self._regex = regex
 
         # Remove any inline comments
         if "#" in line:
@@ -350,7 +351,7 @@ class Repository:
         fileList = [] # type: list[Package]
 
         for file in tqdm.tqdm(indices, position=1, unit=" index", desc="Indices      ", leave=False, disable=not Settings.ProgressBarsEnabled()):
-            fileList += self._ProcessIndex(Settings.SkelPath(), file, False)
+            fileList += self._ProcessIndex(Settings.SkelPath(), file, False, self._regex)
 
         return fileList
 
@@ -367,7 +368,7 @@ class Repository:
         fileList = [] # type: list[Package]
 
         for file in tqdm.tqdm(indices, position=1, unit=" index", desc="Indices      ", leave=False, disable=not Settings.ProgressBarsEnabled()):
-            fileList += self._ProcessIndex(Settings.MirrorPath(), file, True)
+            fileList += self._ProcessIndex(Settings.MirrorPath(), file, True, self._regex)
 
         return fileList
 
@@ -390,7 +391,7 @@ class Repository:
         fileList = [] # type: list[Package]
 
         for file in tqdm.tqdm(indices, position=1, unit=" index", desc="Indices      ", leave=False, disable=not Settings.ProgressBarsEnabled()):
-            fileList += self._ProcessIndex(Settings.SkelPath(), file, True)
+            fileList += self._ProcessIndex(Settings.SkelPath(), file, True, self._regex)
 
         return [x.Filename for x in fileList if x.Latest]
 
@@ -407,7 +408,7 @@ class Repository:
         path = Path(repositoryDirectory)
         return os.path.isdir(path.parent.absolute())
 
-    def _ProcessIndex(self, indexRoot: str, index: str, skipUpdateCheck: bool) -> list[Package]:
+    def _ProcessIndex(self, indexRoot: str, index: str, skipUpdateCheck: bool, regex=None) -> list[Package]:
         """
             Processes each package listed in the Index file.
 
@@ -436,6 +437,9 @@ class Repository:
             if "Filename" in package:
                 # Packages Index
                 filename = package["Filename"]
+
+                if self._regex and not re.search(self._regex, filename):
+                    continue
 
                 if filename.startswith("./"):
                     filename = filename[2:]

--- a/refrapt/refrapt.conf.example
+++ b/refrapt/refrapt.conf.example
@@ -24,7 +24,7 @@ set architecture       = i386
 
 # Specify whether the Contents-[arch].* files should be downloaded.
 set contents           = True
-# The number of threads to use for download and decompression. 
+# The number of threads to use for download and decompression.
 # If not specified here, Refrapt will get the number available from the machine.
 set threads            = 6
 # Specify whether to add the --auth-no-challenge parameter to Wget.
@@ -49,18 +49,18 @@ set certificate        = ""
 set caCertificate      = ""
 # The SSL key to pass to Wget.
 set privateKey         = ""
-# Set the --limit-rate value for each Wget instance. 
+# Set the --limit-rate value for each Wget instance.
 # Note that this will be multipled by the number of threads specified.
 # See Wget manpage for correct syntax
 set limitRate          = 500m # 500 MB
 # Limits the download of Translation files for that of your locale. When not specified, Refrapt will default to locale.getdefaultlocale().
-# Note that "_XX" languages will be stripped of the locale to collect a wider number of files. Ie "en_GB" becomes "en", which will capture 
+# Note that "_XX" languages will be stripped of the locale to collect a wider number of files. Ie "en_GB" becomes "en", which will capture
 # files with the same base language, but different locales.
 # Multiple Languages can also be listed in a comma separated list; for example "en_GB, de_DE".
 # set language           = "en_GB"
 # Tell Refrapt to update all files, regardless of whether they are deemed to have changed or not.
 # Note that if Wget determines the files are unchanged (via Timestamping), this will have no effect.
-# The use of this should be limited for when you know a package has changed, but the size has not 
+# The use of this should be limited for when you know a package has changed, but the size has not
 # (which is how Refrapt determines whether the file needs updating)
 set forceUpdate        = False
 # The log level to use for the application. Possible values are:
@@ -70,7 +70,7 @@ set forceUpdate        = False
 # ERROR
 # CRITICAL
 set logLevel           = INFO
-# Will cause Refrapt to only process the Index files, and determine the list of Binary / Sources files to download, 
+# Will cause Refrapt to only process the Index files, and determine the list of Binary / Sources files to download,
 # and their size, but will not perform the main download. Useful for determining a potential download size before
 # committing to it.
 set test               = False
@@ -99,10 +99,16 @@ set disableProgress    = False
 # Flat repository
 # deb http://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64
 
+# Flat repository with regex
+## This regex matches strings that correspond to a specific package version number, specifically: 10.11.XX
+# regex=10.11.1[1-9] deb https://mirrors.xtom.de/mariadb/repo/10.11/debian bookworm main
+## This regex matches either "vault_1.15" or "vault_1.16", or "consul_1.18" or "consul_1.21".
+# regex=(vault_1\.(15|16)|consul_1.(18|21)) deb https://apt.releases.hashicorp.com bookworm main
+
 ###################
 ## DISABLE CLEAN ##
 ###################
-# Cleaning of unrequired files is enabled by default. To prevent cleaning 
+# Cleaning of unrequired files is enabled by default. To prevent cleaning
 # a particular directory, add the following command
 
 # clean=False deb http://gb.archive.ubuntu.com/ubuntu

--- a/refrapt/refrapt.py
+++ b/refrapt/refrapt.py
@@ -474,7 +474,6 @@ def GetRepositories(configData: list) -> list:
         elif line.startswith("clean=") and "False" in line:
             uri = line.split(' ')[2]
             repository = [x for x in repositories if x.Uri == uri]
-            print(repository[0].Uri)
             repository[0].Clean = False
             logger.debug(f"Not cleaning {uri}")
 

--- a/refrapt/refrapt.py
+++ b/refrapt/refrapt.py
@@ -465,13 +465,16 @@ def ConvertSize(size: int) -> str:
 
 def GetRepositories(configData: list) -> list:
     """Determine the Repositories listed in the Configuration file."""
-    for line in [x for x in configData if x.startswith("deb")]:
-        repositories.append(Repository(line, Settings.Architecture()))
-
-    for line in [x for x in configData if x.startswith("clean")]:
-        if "False" in line:
-            uri = line.split(" ")[1]
+    for line in configData:
+        if line.startswith("deb"):
+            repositories.append(Repository(line, Settings.Architecture(), None))
+        elif line.startswith("regex="):
+            split_line = line.split(' ', 1)
+            repositories.append(Repository(split_line[1], Settings.Architecture(), split_line[0].replace("regex=", "")))
+        elif line.startswith("clean=") and "False" in line:
+            uri = line.split(' ')[2]
             repository = [x for x in repositories if x.Uri == uri]
+            print(repository[0].Uri)
             repository[0].Clean = False
             logger.debug(f"Not cleaning {uri}")
 


### PR DESCRIPTION
Hello

This feature allows to filter package downloads using regular expressions.
Large repositories can consume a lot of local storage space, especially when we only need a small fraction of the packages available.
This feature solves this problem by allowing you to specify a regular expression to filter out unwanted packages.

Activating the regular expression after repository synchronization will clean the local storage space (if the clean option is enabled).

Many thanks