### PR TITLE
Fix ":" in filename

### DIFF
--- a/refrapt/classes.py
+++ b/refrapt/classes.py
@@ -935,7 +935,7 @@ class Index:
                 else:
                     key = line.split(":")[0]
                     if key in keywords:
-                        value = line.split(":")[1].strip()
+                        value = line.split(":",1)[1].strip()
                         package[key] = value
                     else:
                         # Ignore, we don't need it


### PR DESCRIPTION
On certain repositories, notably RabbitMQ, files often have ":" in their version tags. 

Unfortunately on Rafrapt, these files are not downloaded: 
 
 ```
http://ppa1.rabbitmq.com/rabbitmq/rabbitmq-erlang/deb/debian/pool/bookworm/main/e/er/erlang-x11_1:
2025-07-01 08:52:28 ERROR 404: Not Found.
``` 
_Original Filename: pool/bookworm/main/e/er/erlang-x11_1:27.2-1/erlang-x11_27.2-1_all.deb_

I propose this fix to unlock the download. 

Good day. 